### PR TITLE
Version update and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,18 @@ This project was generated with [Angular CLI](https://github.com/angular/angular
 - import { NgaReadMoreModule } from 'nga-read-more';
 - imports: [ NgaReadMoreModule]<br /><br/>
 ## Use it in your component like below :<br/><br/>
-`<nga-read-more [text]="'your text'" [textLength]="20"></nga-read-more>`
+`<nga-read-more [text]="'your text'" [linkColor]="'your color'" [textLength]="20"></nga-read-more>`
 <br /><br />
 Pass `[text]` as input which you want to toggle.<br />
 Pass `[textLength]` as input, it will allow you to hide text if it is more than `textLength`.<br />
+Pass `[linkColor]` as input, Customise link color. Default color is `#0000ff`<br />
 
 > **Note**: If user doesn't pass `textLength`, by default it will show 20 characters. It will work with `angular6,7` also, should also work without any issue with `angular 8` <br /> 
 **In case of issue please open bug at** [Github](https://github.com/alokkarma/nga-read-more/issues)\
 > Feedback and improvements always welcome.
+
+# Update in version 0.0.4
+- Now you can pass `[linkColor]` as input for changing the link color. By Default it would be blue.
+- Fixed bug for `null` values. In case if `null` value is coming it will not through any error or unexpected behaviour.
+- Bug fix if `textLength` is `0` or `-1`. It will make it as default value 20.
+- Removed `<div>` and using `<ng-container>` to make it inline with content.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # NgaReadMore
 
 Simple module for hide and show text. Based on its lenght provided by user.<br /><br />
+> [Github Repo](https://github.com/alokkarma/nga-read-more)
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 7.2.1.
 
 # How to Use

--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ This project was generated with [Angular CLI](https://github.com/angular/angular
 Pass `[text]` as input which you want to toggle.<br />
 Pass `[textLength]` as input, it will allow you to hide text if it is more than `textLength`.<br />
 
-> **Note**: If user doesn't pass `textLength`, by default it will show 20 characters. It will work with `angular6,7` `angular 8` should also work without any issue<br /> 
+> **Note**: If user doesn't pass `textLength`, by default it will show 20 characters. It will work with `angular6,7` also, should also work without any issue with `angular 8` <br /> 
 **In case of issue please open bug at** [Github](https://github.com/alokkarma/nga-read-more/issues)\
 > Feedback and improvements always welcome.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Pass `[linkColor]` as input, Customise link color. Default color is `#0000ff`<br
 **In case of issue please open bug at** [Github](https://github.com/alokkarma/nga-read-more/issues)\
 > Feedback and improvements always welcome.
 
-# Update in version 0.0.4
+# Update in version 0.0.6
 - Now you can pass `[linkColor]` as input for changing the link color. By Default it would be blue.
 - Fixed bug for `null` values. In case if `null` value is coming it will not through any error or unexpected behaviour.
 - Bug fix if `textLength` is `0` or `-1`. It will make it as default value 20.

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ This project was generated with [Angular CLI](https://github.com/angular/angular
 
 - npm install nga-read-more
 - import { NgaReadMoreModule } from 'nga-read-more';
-- imports: [ NgaReadMoreModule]<br />
-Use it in your component like below :<br/><br/>
+- imports: [ NgaReadMoreModule]<br /><br/>
+## Use it in your component like below :<br/><br/>
 `<nga-read-more [text]="'your text'" [textLength]="20"></nga-read-more>`
 <br /><br />
 Pass `[text]` as input which you want to toggle.<br />
 Pass `[textLength]` as input, it will allow you to hide text if it is more than `textLength`.<br />
 
-> **Note**: If user doesn't pass `textLength`, by default it will show 20 characters.  
+> **Note**: If user doesn't pass `textLength`, by default it will show 20 characters. It will work with `angular6,7` `angular 8` should also work without any issue<br /> 
 **In case of issue please open bug at** [Github](https://github.com/alokkarma/nga-read-more/issues)\
 > Feedback and improvements always welcome.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
   "name": "nga-read-more",
+  "description": "create read-more link for large text in angular",
+  "author": "Alok Vishwakarma <alok.lko631@gmail.com>",
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
@@ -48,5 +50,13 @@
     "tslib": "^1.9.0",
     "tslint": "~5.11.0",
     "typescript": "~3.2.2"
-  }
+  },
+  "keywords": [
+    "angular7",
+    "angular",
+    "read-more",
+    "read-more-less"
+  ],
+  "license": "MIT",
+  "repository": "https://github.com/alokkarma/nga-read-more"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nga-read-more",
   "description": "create read-more link for large text in angular",
   "author": "Alok Vishwakarma <alok.lko631@gmail.com>",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nga-read-more",
   "description": "create read-more link for large text in angular",
   "author": "Alok Vishwakarma <alok.lko631@gmail.com>",
-  "version": "0.0.0",
+  "version": "0.0.2",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -52,7 +52,6 @@
     "typescript": "~3.2.2"
   },
   "keywords": [
-    "angular7",
     "angular",
     "read-more",
     "read-more-less"

--- a/projects/nga-read-more-tester/src/app/app.component.html
+++ b/projects/nga-read-more-tester/src/app/app.component.html
@@ -1,1 +1,1 @@
-<nga-read-more [text]="'abc jhhahsdh dshdkahdk dkahd kadh kahdka dhka dkahdkahd kahdad akdha kd'" [textLength]="25"></nga-read-more>
+<p><nga-read-more [text]="'asdssajndajndja asjdnjandjadn'" [textLength]="10"></nga-read-more></p>

--- a/projects/nga-read-more-tester/src/app/app.component.ts
+++ b/projects/nga-read-more-tester/src/app/app.component.ts
@@ -7,4 +7,5 @@ import { Component } from '@angular/core';
 })
 export class AppComponent {
   title = 'nga-read-more-tester';
+  obj ={prop:1};
 }

--- a/projects/nga-read-more/package.json
+++ b/projects/nga-read-more/package.json
@@ -1,8 +1,17 @@
 {
   "name": "nga-read-more",
-  "version": "0.0.1",
+  "description": "create read-more link for large text in angular",
+  "author": "Alok Vishwakarma <alok.lko631@gmail.com>",
+  "version": "0.0.2",
   "peerDependencies": {
     "@angular/common": "^7.2.0",
     "@angular/core": "^7.2.0"
-  }
+  },
+  "keywords": [
+    "angular",
+    "read-more",
+    "read-more-less"
+  ],
+  "license": "MIT",
+  "repository": "https://github.com/alokkarma/nga-read-more"
 }

--- a/projects/nga-read-more/package.json
+++ b/projects/nga-read-more/package.json
@@ -2,7 +2,7 @@
   "name": "nga-read-more",
   "description": "create read-more link for large text in angular",
   "author": "Alok Vishwakarma <alok.lko631@gmail.com>",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "peerDependencies": {
     "@angular/common": "^7.2.0",
     "@angular/core": "^7.2.0"

--- a/projects/nga-read-more/src/lib/nga-read-more.component.ts
+++ b/projects/nga-read-more/src/lib/nga-read-more.component.ts
@@ -3,28 +3,33 @@ import { Component, OnInit, Input } from '@angular/core';
 @Component({
   selector: 'nga-read-more',
   template: `
-  <div>
+  <ng-container>
     <span>{{text}}</span>
-    <a *ngIf="!showOnlyText" style="cursor:pointer;color:#3498db;" (click)="toggleLength()">
+    <a *ngIf="!showOnlyText" [ngStyle]="{'color': linkColor,'cursor': 'pointer'}" (click)="toggleLength()">
       <span *ngIf="!hide">...more</span>
       <span *ngIf="hide">...less</span>
     </a>
-  </div>`,
-  styles: []
+  </ng-container>`
 })
 export class NgaReadMoreComponent implements OnInit {
 
   @Input() text: string;
   @Input() textLength: number;
+  @Input() linkColor:string;
   public showMoreText:string;
   public hide:boolean = true;
   public showOnlyText:boolean = false;
   constructor() { }
 
   ngOnInit() {
-    this.showMoreText = this.text;
-    this.textLength = this.textLength || 20;
-    (this.text.length <= 20 || this.text.length <= this.textLength) ? this.showOnlyText = true : this.toggleLength();
+    if(this.text && typeof this.text === 'string') {
+      this.showMoreText = this.text;
+      this.linkColor = this.linkColor || "#0000ff";
+      this.textLength = this.getLength();
+      (this.text.length <= 20 || this.text.length <= this.textLength) ? this.showOnlyText = true : this.toggleLength();  
+   } else {
+    this.showOnlyText = true;
+   }
   }
   toggleLength() {
     if(this.text.length > this.textLength && this.hide){
@@ -35,5 +40,8 @@ export class NgaReadMoreComponent implements OnInit {
       this.text=this.showMoreText;
     }
   }
-
+ getLength() {
+   if(this.textLength > 0) return this.textLength;
+   return 20;
+ }
 }


### PR DESCRIPTION
# Update in version 0.0.4
- Now you can pass `[linkColor]` as input for changing the link color. By Default it would be blue.
- Fixed bug for `null` values. In case if `null` value is coming it will not through any error or unexpected behaviour.
- Bug fix if `textLength` is `0` or `-1`. It will make it as default value 20.
- Removed `<div>` and using `<ng-container>` to make it inline with content.